### PR TITLE
Update re-direct URL to port 8000

### DIFF
--- a/components/js/device-status.js
+++ b/components/js/device-status.js
@@ -96,7 +96,7 @@ var formats = {
 };
 
 
-var coa_net_passthrough = 'http://10.66.2.64:5000/?'
+var coa_net_passthrough = 'http://10.66.2.64:8000/?'
 
 var SCALE_THRESHOLDS = {
     '$1': 500,


### PR DESCRIPTION
The CCTV service keeps mysteriously becoming unresponsive, and I'm wondering if there's a port conflict. I doubt this is going to resolve the problem, but it's worth a shot.